### PR TITLE
Desync analysis, documentation, and networking robustness fixes

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,6 +1,7 @@
 name: openttd
 queries:
 - uses: security-and-quality
+- uses: ./.github/codeql/queries/deterministic_random.ql
 query-filters:
 - exclude:
     id:

--- a/.github/codeql/queries/deterministic_random.ql
+++ b/.github/codeql/queries/deterministic_random.ql
@@ -1,0 +1,62 @@
+/**
+ * @name Non-deterministic Random() calls
+ * @description Multiple calls to functions that transitively call Random() in expressions with undefined evaluation order can lead to desyncs.
+ * @kind problem
+ * @problem.severity warning
+ * @precision high
+ * @id cpp/openttd/non-deterministic-random
+ * @tags reliability
+ *       maintainability
+ *       network
+ */
+
+import cpp
+
+/** A function that is known to use the synced random generator. */
+class SyncedRandomFunction extends Function {
+  SyncedRandomFunction() {
+    this.hasGlobalName("Random") or
+    this.hasGlobalName("RandomRange") or
+    this.hasGlobalName("Chance16") or
+    this.hasGlobalName("Chance16R")
+  }
+}
+
+/** A function that transitively calls a synced random function. */
+predicate callsSyncedRandom(Function f) {
+  f.getACallee*() instanceof SyncedRandomFunction
+}
+
+/** An expression that transitively calls a synced random function. */
+predicate exprCallsSyncedRandom(Expr e) {
+  exists(FunctionCall call |
+    call = e.getAChild*() and
+    callsSyncedRandom(call.getTarget())
+  )
+}
+
+from Expr parent, Expr child1, Expr child2
+where
+  (
+    // Function arguments - evaluation order is unspecified until C++17,
+    // and even then, interleaving is only partially restricted.
+    exists(FunctionCall call |
+      parent = call and
+      child1 = call.getAnArgument() and
+      child2 = call.getAnArgument() and
+      child1 != child2
+    )
+    or
+    // Binary operators (excluding those with defined order like &&, ||, , and ?:)
+    exists(BinaryOperation op |
+      parent = op and
+      not op instanceof LogicalAndExpr and
+      not op instanceof LogicalOrExpr and
+      not op instanceof CommaExpr and
+      child1 = op.getLeftOperand() and
+      child2 = op.getRightOperand()
+    )
+  ) and
+  exprCallsSyncedRandom(child1) and
+  exprCallsSyncedRandom(child2)
+select parent, "Potential desync: multiple operands/arguments in this expression transitively call Random(), but their evaluation order is undefined."

--- a/docs/desync.md
+++ b/docs/desync.md
@@ -15,6 +15,8 @@ Last updated: 2014-02-23
     - 3.1) [Replaying](#31-replaying)
     - 3.2) [Evaluation of the replay](#32-evaluation-of-the-replay)
     - 3.3) [Comparing savegames](#33-comparing-savegames)
+- 4.0) [Desync Prevention Guide](./desync_prevention.md)
+- 5.0) [Future Desync Tracing Tools and Improvements](./desync_tooling_suggestions.md)
 
 
 ## 1.1) OpenTTD multiplayer architecture

--- a/docs/desync_prevention.md
+++ b/docs/desync_prevention.md
@@ -1,0 +1,59 @@
+# Desync Prevention Guide (Dos and Don'ts)
+
+OpenTTD's multiplayer is based on a deterministic lockstep architecture. Every client must reach the exact same game state after executing the same set of commands. Any deviation, however small, will eventually lead to a desync.
+
+## Random Number Generation (RNG)
+
+### Dos
+- Use `Random()` for anything that affects the game state (e.g., vehicle movement, industry production, map generation).
+- Use `InteractiveRandom()` for things that are strictly local to a client (e.g., UI animations, choosing a random sound effect to play, initial viewport position).
+- Use `Chance16()`, `RandomRange()`, etc., which are wrappers around the synced RNG when appropriate.
+
+### Don'ts
+- **Never** call `Random()` inside a block that is only executed on some clients. This includes:
+    - Blocks guarded by `IsLocalCompany()`.
+    - UI-related code.
+    - Code that depends on `_settings_client`.
+- **Never** use `Random()` in a statement with other `Random()` calls or functions that might call `Random()`. The order of evaluation of function parameters is undefined in C++.
+    - Bad: `DoSomething(Random(), Random());`
+    - Good: `uint32 r1 = Random(); uint32 r2 = Random(); DoSomething(r1, r2);`
+- **Never** call `Random()` inside a `DEBUG()` statement or any code that can be compiled out or disabled via log levels.
+
+## Containers and Iteration
+
+### Dos
+- Use `std::map`, `std::set`, or `std::vector` when you need to iterate over a collection of game-state objects.
+- Use `std::flat_set` or `std::flat_map` for better performance with smaller collections while maintaining deterministic order.
+
+### Don'ts
+- **Never** iterate over `std::unordered_map` or `std::unordered_set` in code that affects the game state. The iteration order depends on hash values and bucket distribution, which can vary between platforms, compiler versions, and even different runs of the same binary.
+    - If you must use these for performance, you **must not** let the iteration order affect the game state (e.g., don't use it to choose the "first" available industry).
+
+## Floating Point Arithmetic
+
+### Dos
+- Use fixed-point arithmetic for game-state calculations. OpenTTD has several fixed-point types and constants (e.g., in `tgp.cpp`, `landscape.cpp`).
+- If you must use floating point for non-critical things, ensure they don't leak into the game state.
+
+### Don'ts
+- **Avoid** `float` and `double` in game-state calculations. Different CPUs and compilers can produce slightly different results for floating point operations (especially transcendental functions like `sin`, `cos`, `pow`, and `sqrt`). These tiny differences will cause desyncs.
+
+## Savegame and Game State
+
+### Dos
+- Ensure every variable that affects the game's progression is saved and loaded in the appropriate `ChunkHandler`.
+- Use `AfterLoad` functions to correctly reconstruct any caches that are not stored in the savegame.
+- Verify that `AfterLoad` logic is deterministic and doesn't depend on local client state.
+
+### Don'ts
+- **Don't** assume that because a variable is "only for drawing" it doesn't need to be synced. If that variable is later used in a calculation that affects the game state, it will cause a desync.
+
+## Command Execution
+
+### Dos
+- Ensure commands are "pure" during their test-run (when `DoCommandFlag::Execute` is NOT set). They should only check for validity and calculate cost.
+- Perform all state changes only when `DoCommandFlag::Execute` is set.
+
+### Don'ts
+- **Don't** modify global variables or pool items during the test-run of a command.
+- **Don't** call `Random()` during the test-run of a command unless you are absolutely sure it's handled correctly by the command system (which generally isn't the case).

--- a/docs/desync_prevention.md
+++ b/docs/desync_prevention.md
@@ -14,8 +14,9 @@ OpenTTD's multiplayer is based on a deterministic lockstep architecture. Every c
     - Blocks guarded by `IsLocalCompany()`.
     - UI-related code.
     - Code that depends on `_settings_client`.
-- **Never** use `Random()` in a statement with other `Random()` calls or functions that might call `Random()`. The order of evaluation of function parameters is undefined in C++.
-    - Bad: `DoSomething(Random(), Random());`
+- **Never** use `Random()` in a statement with other `Random()` calls or functions that might call `Random()`. The order of evaluation of function parameters AND operands of most binary operators is undefined in C++.
+    - Bad (Function arguments): `DoSomething(Random(), Random());`
+    - Bad (Binary operator): `TrainCrashed(t) + TrainCrashed(coll);` (if `TrainCrashed` calls `Random`)
     - Good: `uint32 r1 = Random(); uint32 r2 = Random(); DoSomething(r1, r2);`
 - **Never** call `Random()` inside a `DEBUG()` statement or any code that can be compiled out or disabled via log levels.
 

--- a/docs/desync_tooling_suggestions.md
+++ b/docs/desync_tooling_suggestions.md
@@ -1,0 +1,44 @@
+# Future Desync Tracing Tools and Improvements
+
+Tracing desyncs in the field (on live servers or user machines) is challenging. Based on the analysis of OpenTTD's architecture, here are several suggestions for tools and system enhancements.
+
+## 1. Automated Desync Report Collection
+
+Currently, users must manually locate and attach `commands-out.log` and multiple `dmp_cmds_*.sav` files.
+
+### Suggestion: Desync Report Bundler
+Implement a feature in the game client that, upon a desync:
+- Automatically bundles the relevant log file and the most recent desync savegames into a single compressed archive (e.g., `.zip` or `.tar.gz`).
+- Provides a clear UI dialog to the user with a "Open Folder" or "Copy Path" button.
+
+### Suggestion: Crash/Desync Uploader
+Integrate an optional automated uploader (similar to modern crash reporters) that can send these bundles directly to a centralized server managed by the OpenTTD team (with user consent).
+
+## 2. Server-Side Desync Detection Enhancements
+
+### Suggestion: Continuous State Checksumming
+Currently, OpenTTD uses the RNG state as a checksum. While effective, it can take a long time to diverge after a non-RNG-related state change.
+- Periodically (e.g., every 100 ticks) calculate a more comprehensive (but still fast) hash of critical game state components (e.g., total company money, number of vehicles, industry production levels).
+- Include this hash in the network packets.
+
+## 3. Advanced Debugging Tools
+
+### Suggestion: Headless State Comparator
+A command-line tool that takes two savegames and performs a deep, property-by-property comparison, highlighting exactly which object and which field differ.
+- This would be an improvement over the existing JSON-based comparison, as it could be specialized for the binary format and potentially much faster.
+
+### Suggestion: Desync "Time-Travel" Replay UI
+Enhance the replay functionality with a GUI that allows developers to:
+- See the game state side-by-side with the replayed commands.
+- "Step" through commands one by one.
+- Inspect object properties in real-time during the replay.
+
+## 4. Compile-Time and Runtime Guards
+
+### Suggestion: Non-Deterministic Container Poisoning
+In debug builds, implement a "poisoning" mechanism for `std::unordered_map` and `std::unordered_set` that randomizes the iteration order. This would help catch desyncs caused by non-deterministic iteration much earlier in development.
+
+### Suggestion: Static Analysis for `Random()`
+Add custom static analysis rules (e.g., for Clang-Tidy) that:
+- Detect usage of `Random()` inside non-synced blocks (e.g., UI code).
+- Warn when multiple `Random()` calls are used in the same statement.

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -44,6 +44,8 @@
 #include "table/sprites.h"
 
 #include <unordered_set>
+#include <vector>
+#include <algorithm>
 
 #include "safeguards.h"
 
@@ -1402,8 +1404,12 @@ static std::tuple<bool, bool> FlowRiver(TileIndex spring, TileIndex begin, uint 
 					found = true;
 					break;
 				} else {
-					/* Sea is too small, flatten it so the river keeps looking or forms a lake / wetland. */
-					for (TileIndex sea_tile : sea) {
+					/* Sea is too small, flatten it so the river keeps looking or forms a lake / wetland.
+					 * We need to iterate over the sea tiles in a deterministic order to avoid desyncs. */
+					std::vector<TileIndex> sorted_sea(sea.begin(), sea.end());
+					std::sort(sorted_sea.begin(), sorted_sea.end());
+
+					for (TileIndex sea_tile : sorted_sea) {
 						Command<CMD_TERRAFORM_LAND>::Do(DoCommandFlag::Execute, sea_tile, SLOPE_ELEVATED, false);
 						Slope slope = ComplementSlope(GetTileSlope(sea_tile));
 						Command<CMD_TERRAFORM_LAND>::Do(DoCommandFlag::Execute, sea_tile, slope, true);


### PR DESCRIPTION
This submission addresses possible desync sources in OpenTTD.

Key changes:
1.  **Immediate Fix**: Modified `src/landscape.cpp` to sort sea tiles before iterating over them during river generation. This ensures that the terraforming commands are executed in the same order on all clients, preventing potential desyncs caused by `std::unordered_set` iteration order.
2.  **Documentation**: Created `docs/desync_prevention.md`, which provides a detailed guide for developers on avoiding desyncs. It covers RNG usage, container choice, floating-point arithmetic, and command execution.
3.  **Tooling Proposals**: Created `docs/desync_tooling_suggestions.md` with several suggestions for improving desync detection and tracing in production and development environments.
4.  **Integration**: Updated `docs/desync.md` to include links to the new documentation files.

The changes have been reviewed and verified for correctness. No regressions are expected.

---
*PR created automatically by Jules for task [9504674455234082692](https://jules.google.com/task/9504674455234082692) started by @janisozaur*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a desync prevention guide with rules for deterministic multiplayer behavior
  * Added a page proposing future desync diagnosis tools and UX improvements
  * Updated main desync docs table of contents to reference the new pages

* **Bug Fixes**
  * River-flow terrain adjustments now apply changes in a deterministic tile order

* **Chores**
  * Added a static analysis query to detect risky nondeterministic random usage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->